### PR TITLE
Remove double encoding of item name, description

### DIFF
--- a/catalog/controller/extension/payment/MultiSafepay.combined.php
+++ b/catalog/controller/extension/payment/MultiSafepay.combined.php
@@ -3337,43 +3337,10 @@ class MspItem
      * @param double $numeric_weight the weight of the item
      *
      */
-    function xmlEscape($str)
-    {
-        //$ts = array("/[�-�]/", "/�/", "/�/", "/[�-�]/", "/[�-�]/", "/�/", "/�/", "/[�-��]/", "/�/", "/[�-�]/", "/[�-�]/", "/[�-�]/", "/�/", "/�/", "/[�-�]/", "/[�-�]/", "/�/", "/�/", "/[�-��]/", "/�/", "/[�-�]/", "/[�-�]/");
-        //$tn = array("A", "AE", "C", "E", "I", "D", "N", "O", "X", "U", "Y", "a", "ae", "c", "e", "i", "d", "n", "o", "x", "u", "y");
-        //$str = preg_replace($ts, $tn, $str);
-        //$str = mb_convert_encoding($str, 'UTF-8');
-        //$str = htmlspecialchars($string, ENT_QUOTES);
-        return htmlspecialchars($str, ENT_COMPAT, "UTF-8");
-    }
-
-    /*
-     * Returns the string with all XML escaping removed
-     */
-
-    function xmlUnescape($str)
-    {
-        return html_entity_decode($str, ENT_COMPAT, "UTF-8");
-    }
-
-    /**
-     * {@link http://code.google.com/apis/checkout/developer/index.html#tag_item <item>}
-     *
-     * @param string $name the name of the item -- required
-     * @param string $desc the description of the item -- required
-     * @param integer $qty the number of units of this item the customer has
-     *                    in its shopping cart -- required
-     * @param double $price the unit price of the item -- required
-     * @param string $item_weight the weight unit used to specify the item's
-     *                            weight,
-     *                            one of 'LB' (pounds) or 'KG' (kilograms)
-     * @param double $numeric_weight the weight of the item
-     *
-     */
     function __construct($name, $desc, $qty, $price, $item_weight = '', $numeric_weight = '')
     {
-        $this->item_name = $this->xmlEscape($name);
-        $this->item_description = $this->xmlEscape($desc);
+        $this->item_name = $name;
+        $this->item_description = $desc;
         $this->unit_price = $price;
         $this->quantity = $qty;
 

--- a/catalog/controller/extension/payment/multisafepay.php
+++ b/catalog/controller/extension/payment/multisafepay.php
@@ -291,7 +291,15 @@ class ControllerExtensionPaymentMultiSafePay extends Controller
 
                 $product_name = $this->_getProductName($product);
 
-                $c_item = new MspItem($product_name, strip_tags($product['model']), $product['quantity'], $product['price'], 'KG', $product['weight']);
+                $c_item = new MspItem(
+                    html_entity_decode($product_name, ENT_COMPAT, 'UTF-8'),
+                    html_entity_decode(strip_tags($product['model']), ENT_COMPAT, 'UTF-8'),
+                    $product['quantity'],
+                    $product['price'],
+                    'KG',
+                    $product['weight']
+                );
+
                 $c_item->merchant_item_id = $this->_getUniqueProductID($product);
                 $c_item->SetTaxTableSelector($taxname);
                 $msp->cart->AddItem($c_item);
@@ -580,7 +588,15 @@ class ControllerExtensionPaymentMultiSafePay extends Controller
 
                 $product_name = $this->_getProductName($product);
 
-                $c_item = new MspItem($product_name, strip_tags($product['model']), $product['quantity'], $product['price'], 'KG', $product['weight']);
+                $c_item = new MspItem(
+                    html_entity_decode($product_name, ENT_COMPAT, 'UTF-8'),
+                    html_entity_decode(strip_tags($product['model']), ENT_COMPAT, 'UTF-8'),
+                    $product['quantity'],
+                    $product['price'],
+                    'KG',
+                    $product['weight']
+                );
+
                 $c_item->merchant_item_id = $this->_getUniqueProductID($product);
                 $c_item->SetTaxTableSelector($taxname);
                 $msp->cart->AddItem($c_item);


### PR DESCRIPTION
OpenCart product names containing `&` are shown with `&amp;amp;` in MultiSafepay. That's because they're encoded three times:

* By OpenCart when stored in the database.
* In `XmlItem` when constructing the class.
* In `XmlItem` when generating the XML using `msp_gc_XmlBuilder::Element`.

This PR makes the MultiSafepay payment module pass the decoded values to XmlItem, and removes the excessive encoding in XmlItem.