### PR TITLE
Update multisafepayversioncontrol.php

### DIFF
--- a/src/system/library/multisafepayversioncontrol.php
+++ b/src/system/library/multisafepayversioncontrol.php
@@ -15,7 +15,7 @@ class Multisafepayversioncontrol {
         $this->extension_type = 'payment';
         $this->extension_key  = 'multisafepay';
         $this->lowest_version_supported = '2.0.0.0';
-        $this->higher_version_supported = '3.0.3.9';
+        $this->higher_version_supported = '3.0.4.0';
     }
 
     /**


### PR DESCRIPTION
Support for opencart 3.0.4.0.

I think its best also to change line
if((version_compare($this->oc_version, '3.0.0.0', '>=') && version_compare($this->oc_version, $this->higher_version_supported, '<='))) {
            return '3.0';
        }

into

if((version_compare($this->oc_version, '3.0.0.0', '>=') && version_compare($this->oc_version, '4.0.0.0', '<'))) {
            return '3.0';
        }

I had updated my website to 3.0.4.0 and because minor changes suddenly Multisafepay is not working.



